### PR TITLE
handle media with all captial file extensions

### DIFF
--- a/src/pupil_labs/video/reader.py
+++ b/src/pupil_labs/video/reader.py
@@ -209,9 +209,13 @@ class Reader(Generic[ReaderFrameType]):
     def _container(self) -> av.container.input.InputContainer:
         url = self.source
 
+        # some devices save with an MP4 extension, so just normalize all extensions
+        # to lowercase to cover all possibilities
+        source_lower = self.source
+        source_lower = source_lower.lower()
         container_format = None
         for container_format in ["mp4", "mjpeg", "aac"]:
-            if str(self.source).endswith(container_format):
+            if str(source_lower).endswith(container_format):
                 break
 
         if isinstance(self.source, UPath):

--- a/src/pupil_labs/video/reader.py
+++ b/src/pupil_labs/video/reader.py
@@ -215,7 +215,7 @@ class Reader(Generic[ReaderFrameType]):
         source_lower = source_lower.lower()
         container_format = None
         for container_format in ["mp4", "mjpeg", "aac"]:
-            if str(source_lower).endswith(container_format):
+            if source_lower.endswith(container_format):
                 break
 
         if isinstance(self.source, UPath):

--- a/src/pupil_labs/video/reader.py
+++ b/src/pupil_labs/video/reader.py
@@ -209,8 +209,6 @@ class Reader(Generic[ReaderFrameType]):
     def _container(self) -> av.container.input.InputContainer:
         url = self.source
 
-        # some devices save with an MP4 extension, so just normalize all extensions
-        # to lowercase to cover all possibilities
         source_lower = str(self.source).lower()
         container_format = None
         for container_format in ["mp4", "mjpeg", "aac"]:

--- a/src/pupil_labs/video/reader.py
+++ b/src/pupil_labs/video/reader.py
@@ -211,8 +211,7 @@ class Reader(Generic[ReaderFrameType]):
 
         # some devices save with an MP4 extension, so just normalize all extensions
         # to lowercase to cover all possibilities
-        source_lower = self.source
-        source_lower = source_lower.lower()
+        source_lower = str(self.source).lower()
         container_format = None
         for container_format in ["mp4", "mjpeg", "aac"]:
             if source_lower.endswith(container_format):


### PR DESCRIPTION
Some devices, such as GoPro save their videos with an MP4 extension, rather than mp4. Change is necessary for the egocentric gaze mapper